### PR TITLE
DEV-91658 bump snowdog/module-product-attribute-description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Bumped `snowdog/module-product-attribute-description` version to `1.2.0`
 
 ## [1.12.0] 2022-06-14
 - Moved json files to import from `snowdog/module-alpaca-acm` (#7)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "snowdog/module-csp": "^1.3.2",
     "snowdog/module-category-attributes": "^1.1.0",
     "snowdog/module-menu": "^2.14.0",
-    "snowdog/module-product-attribute-description": "~1.1.1",
+    "snowdog/module-product-attribute-description": "^1.2.0",
     "snowdog/module-shipping-latency": "^1.1.1",
     "snowdog/module-wishlist-unlocker": "^1.0.1",
     "snowdog/theme-frontend-alpaca": "^2.27.0",


### PR DESCRIPTION
Bumping module so it gets listed as outdated during future M2 version upgrades.